### PR TITLE
Correctly handle 'async generators'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ when using `pub const io_mode = .evented;`.
 
 ## Future work
 
+* Make `next()` not async if generator is not `is_async = true`.
+  (Currently `await` always makes it async.)
+
 * Properly `await` (the function that calls) `.run()`,
   to make sure nothing remains 'hanging' after the iterator ends,
   if it is an `is_async = true` generator.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ when using `pub const io_mode = .evented;`.
 
 ## Future work
 
-* Make `next()` not async if generator is not `is_async = true`.
-  (Currently `await` always makes it async.)
-
-* Properly `await` (the function that calls) `.run()`,
-  to make sure nothing remains 'hanging' after the iterator ends,
-  if it is an `is_async = true` generator.
-
 * Add a state diagram for GenIterState transitions in GenIter.
 
 * Add support for various active Zig package managers.

--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,11 @@ const std = @import("std");
 const Builder = std.build.Builder;
 
 pub fn build(b: *Builder) void {
-    var test_step = b.addTest("ziggen.zig");
-    test_step.test_evented_io = true;
-    b.default_step.dependOn(&test_step.step);
+    var test_step_1 = b.addTest("ziggen.zig");
+    test_step_1.test_evented_io = false;
+    b.default_step.dependOn(&test_step_1.step);
+
+    var test_step_2 = b.addTest("ziggen.zig");
+    test_step_2.test_evented_io = true;
+    b.default_step.dependOn(&test_step_2.step);
 }

--- a/ziggen.zig
+++ b/ziggen.zig
@@ -195,7 +195,7 @@ fn EmptySleeper(comptime asy: bool) type {
 
         sleep_time_ms: ?usize = null,
 
-        pub fn run(self: *@This(), y: *Yielder(bool)) void {
+        pub fn run(self: *@This(), _: *Yielder(bool)) void {
             if (self.sleep_time_ms) |ms| {
                 _debug("run(): before sleep\n", .{});
                 std.time.sleep(ms * std.time.ns_per_ms);

--- a/ziggen.zig
+++ b/ziggen.zig
@@ -182,6 +182,28 @@ fn GenIterState(comptime T: type) type {
 
 const expectEqual = std.testing.expectEqual;
 
+const EmptySleeper = struct {
+    pub const is_async = true;
+
+    sleep_time_ms: ?usize = null,
+
+    pub fn run(self: *@This(), y: *Yielder(bool)) void {
+        if (self.sleep_time_ms) |ms| {
+            _debug("run(): before sleep\n", .{});
+            std.time.sleep(ms * std.time.ns_per_ms);
+            _debug("run(): after sleep\n", .{});
+        }
+    }
+};
+
+test "empty sleeper" {
+    _debug("\nSTART\n", .{});
+    defer _debug("END\n", .{});
+    var iter = genIter(EmptySleeper{ .sleep_time_ms = 500 });
+    try expectEqual(@as(?bool, null), iter.next());
+    try expectEqual(@as(?bool, null), iter.next());
+}
+
 const Bits = struct {
     pub const is_async = true;
 

--- a/ziggen.zig
+++ b/ziggen.zig
@@ -166,6 +166,10 @@ fn GenIterState(comptime T: type) type {
                     const i = _debugGenNum();
                     _debug("> {}\n", .{i});
                     resume fp;
+                    // This point is only reached very late; when the event loop ends?
+                    // For some reason, at that point our local state,
+                    // the current stack frame, is not available anymore...
+                    // So we should not be doing anything context-dependent here...
                     _debug("< ?\n", .{});
                 }
             }
@@ -204,7 +208,8 @@ test "empty, sync" {
 }
 
 test "empty, async" {
-    // auto-skipped if not --test-evented-io
+    // auto-skipped if not --test-evented-io, because EmptySleeper(true) is an async generator
+    assert(@import("root").io_mode == .evented);
     _debug("\nSTART\n", .{});
     defer _debug("END\n", .{});
     var iter = genIter(EmptySleeper(true){ .sleep_time_ms = null });
@@ -226,7 +231,8 @@ test "empty sleeper, sync" {
 }
 
 test "empty sleeper, async" {
-    // auto-skipped if not --test-evented-io
+    // auto-skipped if not --test-evented-io, because EmptySleeper(true) is an async generator
+    assert(@import("root").io_mode == .evented);
     _debug("\nSTART\n", .{});
     defer _debug("END\n", .{});
     var iter = genIter(EmptySleeper(true){ .sleep_time_ms = 500 });
@@ -264,8 +270,9 @@ const Bits = struct {
     }
 };
 
-// This test requires --test-evented-io, because Bits is an async generator.
 test "generate all bits, finite iterator" {
+    // auto-skipped if not --test-evented-io, because Bits is an async generator
+    assert(@import("root").io_mode == .evented);
     _debug("\nSTART\n", .{});
     defer _debug("END\n", .{});
     var iter = genIter(Bits{ .sleep_time_ms = 500 });


### PR DESCRIPTION
Correctly handle 'async generators',
as exemplified by the new 'empty generator' tests.

As part of this, simplify the states:
Merge `_yielded`, `_suspended_elsewhere`, and `_returned` into a single `_valued`.

Also, make `zig build` run all tests in both blocking and evented I/O mode.